### PR TITLE
Add Cypress configurations for E2E tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
+    pageLoadTimeout: 5000,
+    baseUrl: 'http://localhost:4200',
+    specPattern: 'cypress/e2e/**/*.spec.{js,jsx,ts,tsx}',
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },


### PR DESCRIPTION
Enhanced the configurations of Cypress in its config file. Added 'pageLoadTimeout' to set a 5-second load time for pages, 'baseUrl' to define testing on local server, and 'specPattern' to locate test specs efficiently. This was necessary to establish basic testing environment and make E2E testing more effective and accurate.

### Please read and mark the following check list before creating a pull request (check one with "x"):

 - [ ] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/ngx-admin/blob/master/CONTRIBUTING.md) guide.
 - [ ] I read and followed the [New Feature Checklist](https://github.com/akveo/ngx-admin/blob/master/DEV_DOCS.md#new-feature-checklist) guide.
 
 #### Short description of what this resolves:
